### PR TITLE
fix (atom_exporter.rs, catcher.rs): fixed clippy warnings

### DIFF
--- a/src/atom_exporter.rs
+++ b/src/atom_exporter.rs
@@ -5,7 +5,7 @@ use atom_syndication;
 
 use entry::Entry;
 
-pub fn export(entries: &Vec<Entry>) {
+pub fn export(entries: &[Entry]) {
     let mut atom_entries = Vec::<atom_syndication::Entry>::new();
     for entry in entries.iter().take(20) {
         let main_link = atom_syndication::Link {


### PR DESCRIPTION
This commit addresses lint warnings reported by the clippy lint tool
on `src/atom_exporter.rs` and `src/catcher.rs`

* warning: returning the result of a let binding from a block. Consider returning the expression directly.
* warning: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices.
* warning: using '.clone()' on a ref-counted pointer
* warning: this argument is passed by value, but not consumed in the function body
* warning: it is more idiomatic to loop over references to containers instead of using explicit iteration methods

These changes do not change the code logic in any way, they only provide
more idiomatic rust :-)

Reference:
--

- https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#let_and_return
- https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#ptr_arg
- https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#clone_on_ref_ptr
- https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#needless_pass_by_value
- https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#explicit_iter_loop

- https://github.com/rust-lang-nursery/rust-clippy